### PR TITLE
Add typing rules for L2

### DIFF
--- a/L2.agda
+++ b/L2.agda
@@ -297,6 +297,9 @@ StoreEnv = 𝕃 → Maybe Tloc
 TypeEnv : Set
 TypeEnv = 𝕏 → Maybe Type
 
+• : TypeEnv
+• = λ {n → nothing}
+
 _,_ : TypeEnv → Type → TypeEnv
 Γ , T = λ { zero → just T; (suc n) → Γ (n) }
 


### PR DESCRIPTION
I'm raising this in a PR for discussion. 

I know that a key idea with regards to the mechanisation is to stay as close to the course notes as possible.

However, I really dislike the abuse of notation with respect to $\Gamma$ (with $\Gamma_\text{Var}$ and $\Gamma_{\text{Loc}}$)

I've changed the notation here to follow the Part II Types course, with $\Sigma$ for store typing and $\Gamma$ for variable typing 

Also would like thoughts on what the syntax for looking up types in the context should look like (right now it's just a function `lookupType`)